### PR TITLE
Branch switching system added

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -33,15 +33,32 @@ async def on_ready():
     print("Logged in as {0.user}".format(bot))
     channel = bot.get_channel(core.vars.channel_testing)
     update = False
+    branch = False
+    if(os.path.exists("branch_success.temp")):
+        file = open("branch.temp","r")
+        branch_name = file.read()
+        file.close()
+        await channel.send("Branch switch to '"+branch_name+"' complete!")
+        os.remove("branch.temp")
+        os.remove("branch_success.temp")
+        branch = True
+    if(os.path.exists("branch_error.temp")):
+        file = open("branch.temp","r")
+        branch_name = file.read()
+        file.close()
+        await channel.send("Branch switch to '"+branch_name+"' failed.\nDouble check the branch name and uncommitted changes.")
+        os.remove("branch.temp")
+        os.remove("branch_error.temp")
+        branch = True
     if(os.path.exists("update_success.temp")):
         await channel.send("Update Complete!")
         os.remove("update_success.temp")
         update = True
     if(os.path.exists("update_error.temp")):
-        await channel.send("Uh oh, something went wrong.\nIf you're on another branch, check if you have any uncommitted changes.")
+        await channel.send("Uh oh, something went wrong.\nCheck if you have any uncommitted changes.")
         os.remove("update_error.temp")
         update = True
-    if(core.vars.debug == False and update == False):
+    if(core.vars.debug == False and update == False and branch == False):
         await channel.send("It's Lapis.")
 
 bot.run(os.environ['DISCORDBOTTOKEN'], reconnect=True)

--- a/branch.py
+++ b/branch.py
@@ -1,0 +1,34 @@
+import subprocess
+import time
+import sys
+import shlex
+import os
+
+print("Starting Branch Script")
+file = open("branch.temp","r")
+branch_name = file.read() #loads the branch name from the temporary file
+file.close()
+try:
+    checkout = str(subprocess.check_output('git checkout '+branch_name,shell=True)) #attempts to checkout to the selected branch
+    print("Successfully switched to '"+branch+"', rebooting bot")
+    successfile = open("branch_success.temp","w+") #to be processed by the bot at boot if present.
+    successfile.close()
+    time.sleep(2)
+    if(sys.platform == 'win32'): #restarts bot on windows systems
+        subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
+    if(sys.platform == 'linux'): #restarts bot on linux systems
+        process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
+    print("Closing Branch Script")
+    time.sleep(3)
+    exit()
+except:
+    errorfile = open("branch_error.temp","w+") #to be processed by the bot at boot if present.
+    errorfile.close()
+    print("Failed git checkout, rebooting bot")
+    if(sys.platform == 'win32'): #restarts bot on windows systems
+        subprocess.run(['start','py','bot.py'],shell=True)
+    if(sys.platform == 'linux'): #restarts bot on linux systems
+        process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE) #same command pulled from update.py
+    print("Closing Branch Script")
+    time.sleep(3)
+    exit()

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -39,12 +39,32 @@ class System(commands.Cog):
                 await ctx.send("Windows: Rebooting for an update!")
                 exit()
             if(sys.platform == 'linux'): #handles updates on linux systems
-                process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 update.py"""), stdout=subprocess.PIPE)
-                print(process.returncode)
+                subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 update.py"""), stdout=subprocess.PIPE)
                 await ctx.send("Linux: Rebooting for an update!")
                 exit()
         else:
             await ctx.send("You do not have permission to use this command.")
+
+    @commands.command()
+    async def branch(self,ctx,branch_name):
+        """ Changes the branch the bot operates on """
+
+        if(ctx.author.id == core.vars.owner_id): #owner only command to change branches
+            if(sys.platform == 'win32'):
+                file = open("branch.temp","w+")
+                file.write(branch_name)
+                file.close()
+                subprocess.run(['start','py','branch.py'],shell=True)
+                await ctx.send("Windows: Rebooting for a branch change to '"+branch_name+"'!")
+                exit()
+            if(sys.platform == 'linux'):
+                file = open("branch.temp","w+")
+                file.write(branch_name)
+                subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 branch.py"""), stdout=subprocess.PIPE)
+                await ctx.send("Linux: Rebooting for a branch change to '"+branch_name+"'!")
+                exit()
+        else:
+            await ctx.send("This is an owner only command.")
 
     @commands.command()
     async def id(self,ctx,user: discord.User=None):

--- a/update.py
+++ b/update.py
@@ -4,20 +4,31 @@ import sys
 import shlex
 
 print("Starting Update Script")
-checkout = str(subprocess.check_output('git checkout master',shell=True))
-if("error" in checkout):
-    errorfile = open("update_error.temp","w+") #to be processed by the bot at boot if present.
+try:
+    checkout = str(subprocess.check_output('git checkout master',shell=True))
+    print("Changed to master branch")
+    subprocess.run('git pull',shell=True)
+    print("Fetched code, making success note")
+    successfile = open("update_success.temp","w+") #to be processed by the bot at boot if present.
+    successfule.close()
+    print("Rebooting bot")
+    time.sleep(2)
+    if(sys.platform == 'win32'): #restarts bot on windows systems
+        subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
+    if(sys.platform == 'linux'): #restarts bot on linux systems
+        process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
+    print("Closing Update Script")
+    time.sleep(3)
     exit()
-print("Changed to master branch")
-subprocess.run('git pull',shell=True)
-print("Fetched code, making success note")
-successfile = open("update_success.temp","w+") #to be processed by the bot at boot if present.
-print("Rebooting bot")
-time.sleep(2)
-if(sys.platform == 'win32'): #restarts bot on windows systems
-    subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
-if(sys.platform == 'linux'): #restarts bot on linux systems
-    process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
-print("Closing Update Script")
-time.sleep(3)
-exit()
+except:
+    errorfile = open("update_error.temp","w+") #to be processed by the bot at boot if present.
+    errorfile.close()
+    print("Failed checkout, rebooting bot")
+    time.sleep(2)
+    if(sys.platform == 'win32'): #restarts bot on windows systems
+        subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
+    if(sys.platform == 'linux'): #restarts bot on linux systems
+        process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
+    print("Closing Update Script")
+    time.sleep(3)
+    exit()


### PR DESCRIPTION
- Gonna use the new beta branch for testing it on the pi, don't wanna 
load into the saveload branch, as I won't be able to come back.
    - Note: Update that branch, possibly delete it and completely 
restructure the Activity Tracking.
-------------------------
bot.py:
    - now includes detection statements for the branch change system.
    - improved the update_error message
branch.py:
    - initial commit
    - All it does is attempt to run a 'git checkout' command and reboot 
the bot.
cogs.system.py:
    - Removed unneeded print statements from the Linux Update Fix mess
    - Added branch command to change branches
        - Currently owner only, may change later to Lapis Lord only
update.py:
    - Improved error handling, now properly reboots the bot no matter 
what.