### PR TITLE
Branch Command Fix

### DIFF
--- a/branch.py
+++ b/branch.py
@@ -20,13 +20,8 @@ try:
         process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
     print("Closing Branch Script")
     time.sleep(3)
-<<<<<<< Updated upstream
-    exit()
-except CalledProcessError:
-=======
     os._exit(0) #forces an exit, avoids triggering the except block
 except:
->>>>>>> Stashed changes
     errorfile = open("branch_error.temp","w+") #to be processed by the bot at boot if present.
     errorfile.close()
     print("Failed checkout to '"+branch_name+"', rebooting bot")

--- a/branch.py
+++ b/branch.py
@@ -15,13 +15,18 @@ try:
     successfile.close()
     time.sleep(2)
     if(sys.platform == 'win32'): #restarts bot on windows systems
-        subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
+        subprocess.run(['start','py','bot.py'],shell=True)
     if(sys.platform == 'linux'): #restarts bot on linux systems
         process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
     print("Closing Branch Script")
     time.sleep(3)
+<<<<<<< Updated upstream
     exit()
 except CalledProcessError:
+=======
+    os._exit(0) #forces an exit, avoids triggering the except block
+except:
+>>>>>>> Stashed changes
     errorfile = open("branch_error.temp","w+") #to be processed by the bot at boot if present.
     errorfile.close()
     print("Failed checkout to '"+branch_name+"', rebooting bot")

--- a/branch.py
+++ b/branch.py
@@ -21,7 +21,7 @@ try:
     print("Closing Branch Script")
     time.sleep(3)
     exit()
-except:
+except CalledProcessError:
     errorfile = open("branch_error.temp","w+") #to be processed by the bot at boot if present.
     errorfile.close()
     print("Failed checkout to '"+branch_name+"', rebooting bot")

--- a/update.py
+++ b/update.py
@@ -6,8 +6,6 @@ import os
 
 print("Starting Update Script")
 try:
-    checkout = str(subprocess.check_output('git checkout master',shell=True))
-    print("Changed to master branch")
     subprocess.run('git pull',shell=True)
     print("Fetched code, making success note")
     successfile = open("update_success.temp","w+") #to be processed by the bot at boot if present.

--- a/update.py
+++ b/update.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 import sys
 import shlex
+import os
 
 print("Starting Update Script")
 try:
@@ -10,23 +11,23 @@ try:
     subprocess.run('git pull',shell=True)
     print("Fetched code, making success note")
     successfile = open("update_success.temp","w+") #to be processed by the bot at boot if present.
-    successfule.close()
+    successfile.close()
     print("Rebooting bot")
     time.sleep(2)
     if(sys.platform == 'win32'): #restarts bot on windows systems
-        subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
+        subprocess.run(['start','py','bot.py'],shell=True)
     if(sys.platform == 'linux'): #restarts bot on linux systems
         process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
     print("Closing Update Script")
     time.sleep(3)
-    exit()
-except CalledProcessError:
+    os._exit(0) #forces an exit, avoids triggering the except block
+except:
     errorfile = open("update_error.temp","w+") #to be processed by the bot at boot if present.
     errorfile.close()
     print("Failed checkout, rebooting bot")
     time.sleep(2)
     if(sys.platform == 'win32'): #restarts bot on windows systems
-        subprocess.run(['start','py',dir+'\\bot.py'],shell=True)
+        subprocess.run(['start','py','bot.py'],shell=True)
     if(sys.platform == 'linux'): #restarts bot on linux systems
         process = subprocess.Popen(shlex.split("""x-terminal-emulator -e python3.7 bot.py"""), stdout=subprocess.PIPE)
     print("Closing Update Script")

--- a/update.py
+++ b/update.py
@@ -22,7 +22,7 @@ try:
 except:
     errorfile = open("update_error.temp","w+") #to be processed by the bot at boot if present.
     errorfile.close()
-    print("Failed checkout, rebooting bot")
+    print("Update failed, rebooting bot")
     time.sleep(2)
     if(sys.platform == 'win32'): #restarts bot on windows systems
         subprocess.run(['start','py','bot.py'],shell=True)

--- a/update.py
+++ b/update.py
@@ -20,7 +20,7 @@ try:
     print("Closing Update Script")
     time.sleep(3)
     exit()
-except:
+except CalledProcessError:
     errorfile = open("update_error.temp","w+") #to be processed by the bot at boot if present.
     errorfile.close()
     print("Failed checkout, rebooting bot")


### PR DESCRIPTION
Fixing the branch command, we can now switch branches easily!
- Fixed a whole lot of syntax and variable name issues
- Made branch.py and update.py force exit if successful to avoid triggering the except block used for handling errors.
- We no longer force a branch change when updating
- Removed some nonsense that appeared randomly.